### PR TITLE
Allow docker to access host USB devices

### DIFF
--- a/ansible/roles/products/common/docker-container/defaults/main.yml
+++ b/ansible/roles/products/common/docker-container/defaults/main.yml
@@ -32,6 +32,7 @@ haptx_teleop_readthedocs_token: ""
 arm_hand_readthedocs_token: ""
 glove: ""
 common_shared_volumes:
+  - /dev/bus/usb:/dev/bus/usb
   - /tmp/.X11-unix:/tmp/.X11-unix[rw]
   - /dev/input:/dev/input[rw]
   - /run/udev/data:/run/udev/data


### PR DESCRIPTION
This allows our docker to access the host USB devices. This solves problems like the necessity of plugging the USB device before the container is started.