### PR TITLE
Src 5562 hazard lights

### DIFF
--- a/ansible/playbooks/molecule_docker/molecule/teleop_server_desktop_icons_haptx_bimanual_docker/tests/test_teleop_server.py
+++ b/ansible/playbooks/molecule_docker/molecule/teleop_server_desktop_icons_haptx_bimanual_docker/tests/test_teleop_server.py
@@ -16,7 +16,7 @@ def test_udev_files(host):
     udev_rules = (
         '60-HTC-Vive-perms-Ubuntu.rules',
         '99-steam-perms.rules',
-        '90-VEC-USB-Footpedal.rules'
+        '90-VEC-USB-Footpedal.rules',
         '90-hazard-light.rules'
         )
     for udev_rule in udev_rules:

--- a/ansible/playbooks/molecule_docker/molecule/teleop_server_desktop_icons_haptx_bimanual_docker/tests/test_teleop_server.py
+++ b/ansible/playbooks/molecule_docker/molecule/teleop_server_desktop_icons_haptx_bimanual_docker/tests/test_teleop_server.py
@@ -17,6 +17,7 @@ def test_udev_files(host):
         '60-HTC-Vive-perms-Ubuntu.rules',
         '99-steam-perms.rules',
         '90-VEC-USB-Footpedal.rules'
+        '90-hazard-light.rules'
         )
     for udev_rule in udev_rules:
         assert host.file(udev_path + udev_rule).exists

--- a/ansible/roles/products/teleop/server/deploy/tasks/main.yml
+++ b/ansible/roles/products/teleop/server/deploy/tasks/main.yml
@@ -342,6 +342,13 @@
     mode: '0644'
   become: yes
 
+- name: Udev rules for hazard light
+  get_url:
+    url: https://raw.githubusercontent.com/shadow-robot/sr_teleop_devices/noetic-devel/sr_hazard_light/90-hazard-light.rules
+    dest: /etc/udev/rules.d/90-hazard-light.rules
+    mode: '0644'
+  become: yes
+
 - name: Reload udev rules
   shell: udevadm control --reload-rules && udevadm trigger
   changed_when: false


### PR DESCRIPTION
## Proposed changes

Adding hazard light udev.rules for SRC-5562 and https://github.com/shadow-robot/sr_teleop_devices/pull/40

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [X] Manually tested that added code works as intended (if any functional/runnable code is added).
- [X] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [X] Tested on real hardware (if the changed or added code is used with the real hardware).
- [X] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
