### PR TITLE
Update path udev rules pedal

### DIFF
--- a/ansible/roles/products/teleop/server/deploy/tasks/main.yml
+++ b/ansible/roles/products/teleop/server/deploy/tasks/main.yml
@@ -337,7 +337,7 @@
 
 - name: Udev rules for pedal
   get_url:
-    url: https://raw.githubusercontent.com/shadow-robot/sr_teleop_devices/kinetic-devel/sr_pedal/90-VEC-USB-Footpedal.rules
+    url: https://raw.githubusercontent.com/shadow-robot/sr_teleop_devices/noetic-devel/sr_pedal/90-VEC-USB-Footpedal.rules
     dest: /etc/udev/rules.d/90-VEC-USB-Footpedal.rules
     mode: '0644'
   become: yes


### PR DESCRIPTION
## Proposed changes

Adjust path for pedal udev rules. From kinetic to melodic the udev rules have changed, that's why it was breaking.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
