### PR TITLE
SRC-6063 Wait for trajectory topic instead of sleeping

### DIFF
--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-bimanual.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-bimanual.j2
@@ -32,7 +32,7 @@ wait_for_topic () {
   proceed=false
   while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
     elapsed_time=$(( SECONDS - start_time ))
-    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = *"${1}"* ]]; then
       proceed=true
       break;
     fi

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-bimanual.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-bimanual.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks:False
 #!/bin/bash
 
-CONST_TIMEOUT=20
+CONST_TIMEOUT=60
 
 terminator --geometry "{{ term_1 }}" -T 'Launching server container...' -e "{{ shadow_hand_launcher_folder}}/shadow_server_container.sh"
 
@@ -24,25 +24,33 @@ fi
 
 terminator --geometry "{{ term_2 }}" -T 'Server ROS Core' -e "{{ shadow_hand_launcher_folder}}/shadow_roscore.sh"
 
-elapsed_time=0
-start_time=$SECONDS
-proceed=false
-while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
-  elapsed_time=$(( SECONDS - start_time ))
-  if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = */rosout* ]]; then
-    proceed=true
-    break;
-  fi
-done
-
-if [ "$proceed" == false ]; then
-    zenity --error --text="Roscore not running, execution stopped"
+# Arg1: Topic name to wait for
+# Arg2: Error message to display if topic doesn't appear until timeout
+wait_for_topic () {
+  elapsed_time=0
+  start_time=$SECONDS
+  proceed=false
+  while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
+    elapsed_time=$(( SECONDS - start_time ))
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+      proceed=true
+      break;
+    fi
+  done
+  if [ "$proceed" == false ]; then
+    zenity --error --text="${2}"
     docker stop {{ container_name }}
     exit 1
-fi
+  fi
+}
+
+wait_for_topic "/rosout" "Roscore not running, execution stopped"
 
 terminator --geometry "{{ term_3 }}" -T 'NUC bimanual hardware control loop' -e "{{ shadow_hand_launcher_folder}}/shadow_nuc_bimanual_hardware_control_loop.sh"
-sleep 30 # temporary workaround until arm controllers starting on time is fixed
+
+wait_for_topic "/la_trajectory_controller/state" "Couldn't find left arm trajectory topic"
+wait_for_topic "/ra_trajectory_controller/state" "Couldn't find right arm trajectory topic"
+
 terminator --geometry "{{ term_4 }}" -T 'Server bimanual GUI' -e "{{ shadow_hand_launcher_folder}}/shadow_GUI_bimanual.sh"
 if [[ "{{ glove }}" == "haptx"  ]]; then
   terminator --geometry "{{ term_5 }}" -T 'Server HaptX Bimanual Mapping' -e "{{ shadow_hand_launcher_folder}}/shadow_haptx_mapping_launch_bimanual.sh"

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
@@ -32,7 +32,7 @@ wait_for_topic () {
   proceed=false
   while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
     elapsed_time=$(( SECONDS - start_time ))
-    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = *"${1}"* ]]; then
       proceed=true
       break;
     fi

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks:False
 #!/bin/bash
 
-CONST_TIMEOUT=20
+CONST_TIMEOUT=60
 
 terminator --geometry "{{ term_1 }}" -T 'Launching server container...' -e "{{ shadow_hand_launcher_folder}}/shadow_server_container.sh"
 

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-left.j2
@@ -24,25 +24,32 @@ fi
 
 terminator --geometry "{{ term_2 }}" -T 'Server ROS Core' -e "{{ shadow_hand_launcher_folder}}/shadow_roscore.sh"
 
-elapsed_time=0
-start_time=$SECONDS
-proceed=false
-while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
-  elapsed_time=$(( SECONDS - start_time ))
-  if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = */rosout* ]]; then
-    proceed=true
-    break;
-  fi
-done
-
-if [ "$proceed" == false ]; then
-    zenity --error --text="Roscore not running, execution stopped"
+# Arg1: Topic name to wait for
+# Arg2: Error message to display if topic doesn't appear until timeout
+wait_for_topic () {
+  elapsed_time=0
+  start_time=$SECONDS
+  proceed=false
+  while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
+    elapsed_time=$(( SECONDS - start_time ))
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+      proceed=true
+      break;
+    fi
+  done
+  if [ "$proceed" == false ]; then
+    zenity --error --text="${2}"
     docker stop {{ container_name }}
     exit 1
-fi
+  fi
+}
+
+wait_for_topic "/rosout" "Roscore not running, execution stopped"
 
 terminator --geometry "{{ term_3 }}" -T 'NUC left hand hardware control loop' -e "{{ shadow_hand_launcher_folder}}/shadow_nuc_left_hardware_control_loop.sh"
-sleep 30 # temporary workaround until arm controllers starting on time is fixed
+
+wait_for_topic "/la_trajectory_controller/state" "Couldn't find left arm trajectory topic"
+
 terminator --geometry "{{ term_4 }}" -T 'Server left hand GUI' -e "{{ shadow_hand_launcher_folder}}/shadow_GUI_left.sh"
 if [[ "{{ glove }}" == "haptx"  ]]; then
   terminator --geometry "{{ term_5 }}" -T 'Server HaptX Left Mapping' -e "{{ shadow_hand_launcher_folder}}/shadow_haptx_mapping_launch_left.sh"

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
@@ -32,7 +32,7 @@ wait_for_topic () {
   proceed=false
   while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
     elapsed_time=$(( SECONDS - start_time ))
-    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = *"${1}"* ]]; then
       proceed=true
       break;
     fi

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
@@ -24,25 +24,32 @@ fi
 
 terminator --geometry "{{ term_2 }}" -T 'Server ROS Core' -e "{{ shadow_hand_launcher_folder}}/shadow_roscore.sh"
 
-elapsed_time=0
-start_time=$SECONDS
-proceed=false
-while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
-  elapsed_time=$(( SECONDS - start_time ))
-  if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = */rosout* ]]; then
-    proceed=true
-    break;
-  fi
-done
-
-if [ "$proceed" == false ]; then
-    zenity --error --text="Roscore not running, execution stopped"
+# Arg1: Topic name to wait for
+# Arg2: Error message to display if topic doesn't appear until timeout
+wait_for_topic () {
+  elapsed_time=0
+  start_time=$SECONDS
+  proceed=false
+  while [ $elapsed_time -lt $CONST_TIMEOUT ]; do
+    elapsed_time=$(( SECONDS - start_time ))
+    if [[ "$(docker exec -ti {{ container_name }} bash -c "source /home/user/projects/shadow_robot/base/devel/setup.bash;rostopic list")" = "*${1}*" ]]; then
+      proceed=true
+      break;
+    fi
+  done
+  if [ "$proceed" == false ]; then
+    zenity --error --text="${2}"
     docker stop {{ container_name }}
     exit 1
-fi
+  fi
+}
+
+wait_for_topic "/rosout" "Roscore not running, execution stopped"
 
 terminator --geometry "{{ term_3 }}" -T 'NUC right hand hardware control loop' -e "{{ shadow_hand_launcher_folder}}/shadow_nuc_right_hardware_control_loop.sh"
-sleep 30 # temporary workaround until arm controllers starting on time is fixed
+
+wait_for_topic "/ra_trajectory_controller/state" "Couldn't find right arm trajectory topic"
+
 terminator --geometry "{{ term_4 }}" -T 'Server right hand GUI' -e "{{ shadow_hand_launcher_folder}}/shadow_GUI_right.sh"
 if [[ "{{ glove }}" == "haptx"  ]]; then
   terminator --geometry "{{ term_5 }}" -T 'Server HaptX Right Mapping' -e "{{ shadow_hand_launcher_folder}}/shadow_haptx_mapping_launch_right.sh"

--- a/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
+++ b/ansible/roles/products/teleop/server/desktop-icons/templates/scripts/launch-teleop-right.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks:False
 #!/bin/bash
 
-CONST_TIMEOUT=20
+CONST_TIMEOUT=60
 
 terminator --geometry "{{ term_1 }}" -T 'Launching server container...' -e "{{ shadow_hand_launcher_folder}}/shadow_server_container.sh"
 


### PR DESCRIPTION
## Proposed changes

Sleeping for 30 seconds doesn't always seem to be enough for controllers to start. In order to not block startup when controllers do start early now scripts would wait for appearance of trajectory topics. Waiting timeout was increased to 1 minute.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
