### PR TITLE
Removed forward slash from folder location in S3 task to pull docs

### DIFF
--- a/ansible/roles/products/common/documentation/tasks/main.yml
+++ b/ansible/roles/products/common/documentation/tasks/main.yml
@@ -122,7 +122,7 @@
     aws_secret_key: "{{ aws_secret }}"
     security_token: "{{ aws_security_token }}"
     bucket: "{{ bucket_name }}"
-    object: "/{{ documentation_folder }}/{{ documentation_file }}"
+    object: "{{ documentation_folder }}/{{ documentation_file }}"
     dest: "{{ manual_folder }}/{{ manual_filename }}"
     mode: get
   when: not skip_molecule_task|bool
@@ -133,7 +133,7 @@
     aws_access_key: "{{ aws_key }}"
     aws_secret_key: "{{ aws_secret }}"
     bucket: "{{ bucket_name }}"
-    object: "/{{ documentation_folder }}/{{ documentation_file }}"
+    object: "{{ documentation_folder }}/{{ documentation_file }}"
     dest: "{{ manual_folder }}/{{ manual_filename }}"
     mode: get
   when: skip_molecule_task|bool


### PR DESCRIPTION
## Proposed changes

Removed forward slash from folder location in S3 task to pull docs. Recent API changes seem to have broken it on fresh installs (Tested in VM fresh install and locally on my machine with an older AWS CLI where aurora was still working).

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
