### PR TITLE
Copy ssh key into docker container for the hand_e server PC

### DIFF
--- a/ansible/roles/products/hand-e/server/deploy/tasks/main.yml
+++ b/ansible/roles/products/hand-e/server/deploy/tasks/main.yml
@@ -165,6 +165,12 @@
   changed_when: false
   when: not skip_molecule_task|bool
 
+- name: Copying ssh key pair into docker container
+  changed_when: false
+  shell: "docker cp {{ ssh_keys_path }} {{ container_name }}:/tmp/."
+  become: yes
+  when: groups['server'] is defined
+
 - name: Include products/common/hand_config role
   include_role:
     name: products/common/hand_config


### PR DESCRIPTION
## Proposed changes

This is allowing the container in the server to ssh into the NUC host.
This is something we were already doing for the teleop server deployment.
It was missing from han E and it made some checks by the watchdog fail (NUC governor, drive occupancy etc) in a hand and glove deployment.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
