### PR TITLE
F #src 7342 test focal packages on jammy

### DIFF
--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -283,7 +283,9 @@ while IFS= read -r line; do
     fi
 done < <(lsb_release -a 2>/dev/null)
 
-codename="focal"
+if [[ $codename == *"jammy"* ]]; then
+  codename="focal"
+fi
 
 mkdir -p $miniconda_install_root
 attempts=1

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -283,6 +283,7 @@ while IFS= read -r line; do
     fi
 done < <(lsb_release -a 2>/dev/null)
 
+# We use this variable to figure out which pip packages to download. Packages for focal work on jammy, but bionic needs its own packages
 if [[ $codename == *"jammy"* ]]; then
   codename="focal"
 fi

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -283,6 +283,7 @@ while IFS= read -r line; do
     fi
 done < <(lsb_release -a 2>/dev/null)
 
+codename="focal"
 
 mkdir -p $miniconda_install_root
 attempts=1

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -275,18 +275,6 @@ echo ""
 
 pushd $aurora_home
 
-
-re="^Codename:[[:space:]]+(.*)"
-while IFS= read -r line; do
-    if [[ $line =~ $re ]]; then
-        codename="${BASH_REMATCH[1]}"
-    fi
-done < <(lsb_release -a 2>/dev/null)
-
-if [[ $codename == *"jammy"* ]]; then
-  codename="focal"
-fi
-
 mkdir -p $miniconda_install_root
 attempts=1
 while ! $(echo "${miniconda_checksum} ${miniconda_installer}" | sha256sum --status --check); do
@@ -353,8 +341,8 @@ fetch_new_files() {
   fi
 }
 
-fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "pip_packages"
-fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "ansible_collections"
+fetch_new_files "http://shadowrobot.aurora-host-packages-focal.s3.eu-west-2.amazonaws.com" "pip_packages"
+fetch_new_files "http://shadowrobot.aurora-host-packages-focal.s3.eu-west-2.amazonaws.com" "ansible_collections"
 ANSIBLE_SKIP_CONFLICT_CHECK=1 python -m pip install ${packages_download_root}/pip_packages/*
 
 

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -311,8 +311,8 @@ fi
 ${miniconda_install_location}/bin/conda create -y -n ${conda_ws_name} python=3.8 && source ${miniconda_install_location}/bin/activate ${conda_ws_name}
 python -m pip install yq xq
 fetch_new_files() {
-  old_IFS=$IFS
-  IFS=$'\n'
+  # old_IFS=$IFS
+  # IFS=$'\n'
   aws_bucket_url=$1
   aws_bucket_dir=$2
   local_download_dir="${packages_download_root}/${aws_bucket_dir}"
@@ -351,7 +351,7 @@ fetch_new_files() {
       fi
     done
   fi
-  IFS=${old_IFS}
+  # IFS=${old_IFS}
 }
 
 fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "pip_packages"

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -313,8 +313,6 @@ fi
 ${miniconda_install_location}/bin/conda create -y -n ${conda_ws_name} python=3.8 && source ${miniconda_install_location}/bin/activate ${conda_ws_name}
 python -m pip install yq xq
 fetch_new_files() {
-  # old_IFS=$IFS
-  # IFS=$'\n'
   aws_bucket_url=$1
   aws_bucket_dir=$2
   local_download_dir="${packages_download_root}/${aws_bucket_dir}"
@@ -353,7 +351,6 @@ fetch_new_files() {
       fi
     done
   fi
-  # IFS=${old_IFS}
 }
 
 fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "pip_packages"

--- a/bin/run-ansible.sh
+++ b/bin/run-ansible.sh
@@ -275,6 +275,18 @@ echo ""
 
 pushd $aurora_home
 
+
+re="^Codename:[[:space:]]+(.*)"
+while IFS= read -r line; do
+    if [[ $line =~ $re ]]; then
+        codename="${BASH_REMATCH[1]}"
+    fi
+done < <(lsb_release -a 2>/dev/null)
+
+if [[ $codename == *"jammy"* ]]; then
+  codename="focal"
+fi
+
 mkdir -p $miniconda_install_root
 attempts=1
 while ! $(echo "${miniconda_checksum} ${miniconda_installer}" | sha256sum --status --check); do
@@ -341,8 +353,8 @@ fetch_new_files() {
   fi
 }
 
-fetch_new_files "http://shadowrobot.aurora-host-packages-focal.s3.eu-west-2.amazonaws.com" "pip_packages"
-fetch_new_files "http://shadowrobot.aurora-host-packages-focal.s3.eu-west-2.amazonaws.com" "ansible_collections"
+fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "pip_packages"
+fetch_new_files "http://shadowrobot.aurora-host-packages-${codename}.s3.eu-west-2.amazonaws.com" "ansible_collections"
 ANSIBLE_SKIP_CONFLICT_CHECK=1 python -m pip install ${packages_download_root}/pip_packages/*
 
 


### PR DESCRIPTION
## Proposed changes

If we're on jammy, use focal packages
Also fix bug related to the input field separator (no longer breaks the script if you have any files locally that weren't in the s3 bucket)

Tested by:
```
pip download -r ansible/data/ansible/requirements.txt
```
.. on both focal and jammy

* binary diff between jammy and focal packages shows no diff
* aurora docker_deploy doesn't fail on a vm
* aurora server_and_nuc doesn't fail on a jammy server with focal nuc