### PR TITLE
SRC-7365 make sure terminator var is treated as bool in reinstall.yml

### DIFF
--- a/ansible/roles/products/common/docker-container/tasks/reinstall.yml
+++ b/ansible/roles/products/common/docker-container/tasks/reinstall.yml
@@ -39,23 +39,23 @@
   changed_when: false
 
 - name: Creating the container which will execute setup script in terminator when started
-  when: "not nvidia_docker|bool and terminator and setup_script | length > 0"
+  when: "not nvidia_docker|bool and terminator|bool and setup_script | length > 0"
   include_tasks: create-container/with-setup-with-terminator.yml
 
 - name: Creating the container which will execute setup script when started without terminator
-  when: "not nvidia_docker|bool and not terminator and setup_script | length > 0"
+  when: "not nvidia_docker|bool and not terminator|bool and setup_script | length > 0"
   include_tasks: create-container/with-setup-no-terminator.yml
 
 - name: Creating the container which will just start a terminator (no setup script)
-  when: "not nvidia_docker|bool and terminator and setup_script | length == 0"
+  when: "not nvidia_docker|bool and terminator|bool and setup_script | length == 0"
   include_tasks: create-container/no-setup-with-terminator.yml
 
 - name: Creating the container which will not even start terminator (no setup script)
-  when: "not nvidia_docker|bool and not terminator and setup_script | length == 0"
+  when: "not nvidia_docker|bool and not terminator|bool and setup_script | length == 0"
   include_tasks: create-container/no-setup-no-terminator.yml
 
 - name: Creating the container which will execute setup script in terminator when started (NVIDIA)
-  when: "nvidia_docker|bool and terminator and setup_script | length > 0"
+  when: "nvidia_docker|bool and terminator|bool and setup_script | length > 0"
   include_tasks: create-container/nvidia-with-setup-with-terminator.yml
 
 - name: Move response back to container


### PR DESCRIPTION
## Proposed changes

true/false passed in via the CLI gets stored as a string
Make sure the `terminator` arg is treated as a boolean

Before this PR, when passing in terminator=false to the oneliner:
```
when: terminator
```
evaluates to true
```
when: terminator|bool
```
evaluates to false

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
