### PR TITLE
Update server_and_nuc_deploy.yml

### DIFF
--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -88,6 +88,11 @@
 - name: Install Hand software on Ubuntu server laptop
   hosts: server
   pre_tasks:
+    - name: Install licence tools
+      include_role:
+        name: installation/install_licence_tools
+      when: '"binary" in image'
+
     - name: check if customer_key is provided and not false
       when: customer_key is defined and customer_key | length > 0
       set_fact:
@@ -114,7 +119,6 @@
       become: yes
 
   roles:
-    - { role: installation/install_licence_tools, when: '"binary" in image'}
     - { role: products/common/get-system-variables }
     - { role: products/hand-e/server/deploy }
     - { role: products/common/dolphin-icons, when: ansible_distribution_release|string == 'focal' or ansible_distribution_release|string == 'jammy'}

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -114,10 +114,10 @@
       become: yes
 
   roles:
+    - { role: installation/install_licence_tools, when: "binary" in image|string}
     - { role: products/common/get-system-variables }
     - { role: products/hand-e/server/deploy }
     - { role: products/common/dolphin-icons, when: ansible_distribution_release|string == 'focal' or ansible_distribution_release|string == 'jammy'}
-    - { role: installation/install_licence_tools, when: "binary" in image|string}
 
 - name: Install Hand software on control machine
   hosts: control_machine

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -70,8 +70,10 @@
   import_playbook: ./install_python3.yml
 
 - name: Install licence tools
-  include_role:
-    name: installation/install_licence_tools
+  tasks:
+    - name: Include install_licence_tools role
+      include_role:
+        name: installation/install_licence_tools
   when: '"binary" in image'
 
 - name: Check which hosts are available for server and control machine system Install

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -28,11 +28,6 @@
       include_role:
         name: installation/playbook_setup
       when: not skip_molecule_task|bool
-
-    - name: Install licence tools
-      include_role:
-        name: installation/install_licence_tools
-      when: '"binary" in image'
   tasks:
     - name: Extract hostname from server
       set_fact:
@@ -73,6 +68,11 @@
 
 - name: Install Python 3
   import_playbook: ./install_python3.yml
+
+- name: Install licence tools
+  include_role:
+    name: installation/install_licence_tools
+  when: '"binary" in image'
 
 - name: Check which hosts are available for server and control machine system Install
   hosts: all

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -114,7 +114,7 @@
       become: yes
 
   roles:
-    - { role: installation/install_licence_tools, when: "binary" in image|string}
+    - { role: installation/install_licence_tools, when: '"binary" in image'}
     - { role: products/common/get-system-variables }
     - { role: products/hand-e/server/deploy }
     - { role: products/common/dolphin-icons, when: ansible_distribution_release|string == 'focal' or ansible_distribution_release|string == 'jammy'}

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -69,13 +69,6 @@
 - name: Install Python 3
   import_playbook: ./install_python3.yml
 
-- name: Install licence tools
-  tasks:
-    - name: Include install_licence_tools role
-      include_role:
-        name: installation/install_licence_tools
-      when: '"binary" in image'
-
 - name: Check which hosts are available for server and control machine system Install
   hosts: all
   gather_facts: no
@@ -124,6 +117,7 @@
     - { role: products/common/get-system-variables }
     - { role: products/hand-e/server/deploy }
     - { role: products/common/dolphin-icons, when: ansible_distribution_release|string == 'focal' or ansible_distribution_release|string == 'jammy'}
+    - { role: installation/install_licence_tools, when: "binary" in image|string}
 
 - name: Install Hand software on control machine
   hosts: control_machine

--- a/ansible/playbooks/server_and_nuc_deploy.yml
+++ b/ansible/playbooks/server_and_nuc_deploy.yml
@@ -74,7 +74,7 @@
     - name: Include install_licence_tools role
       include_role:
         name: installation/install_licence_tools
-  when: '"binary" in image'
+      when: '"binary" in image'
 
 - name: Check which hosts are available for server and control machine system Install
   hosts: all

--- a/ansible/roles/docker/ecr/tasks/main.yml
+++ b/ansible/roles/docker/ecr/tasks/main.yml
@@ -147,7 +147,7 @@
             raw: 'apt-get -y update && apt-get purge -y python3-openssl'
             register: output
             when:
-              - ansible_failed_result.stderr | regex_search("module 'lib' has no attribute 'X509_V_FLAG_.*")
+              - ansible_failed_result.module_stderr | regex_search("module 'lib' has no attribute 'X509_V_FLAG_.*")
             become: yes
 
           - name: Re-try install Python dependencies (not in conda)


### PR DESCRIPTION
## Proposed changes

The "install_python3.yaml" task sets a variable called "ansible_pip3_executable". The install_licence_tools task reads this variable. Currently "install_licence_tools" is being called before the "install_python3" task, so the variable hasn't been set and aurora breaks

Also, `ansible_failed_result` doesn't seem to have a key (during failure) called stderr

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
